### PR TITLE
Adding a memory cache expiry feature

### DIFF
--- a/cacher/cache_test.go
+++ b/cacher/cache_test.go
@@ -11,7 +11,7 @@ import (
 // TODO: This should be replaced by a mock, not use memory engine
 
 func TestCacher_Get(t *testing.T) {
-	e := engine.NewMemoryStore()
+	e := engine.NewMemoryStore(time.Second * 60)
 	cache := NewCacher(e, 5, 5)
 	count := 0
 	content := []byte("hello")

--- a/engine/memory/engine.go
+++ b/engine/memory/engine.go
@@ -68,7 +68,7 @@ func (e *Engine) Put(key string, data []byte, expiry time.Time) error {
 // IsExpired checks to see if the key has expired
 func (e *Engine) IsExpired(key string) bool {
 	if time.Now().After(e.expire[key]) {
-		e.Expire(key)
+		go e.Expire(key)
 		return true
 	}
 	return false


### PR DESCRIPTION
Change: Adding a feature to expire stored items.

A new poller has been added that iterates through the keys and if a key has expired it will be removed. The frequency of this poller is set as an argument when calling the NewMemoryStore function.

When checking the IsExpired status the function now will remove keys which have expired.

Test cases have been updated to check the cleanup poller is working as expected and the IsExpired function can now return true/false.

This is potentially a breaking change as you now have to pass a time.Duration to the NewMemoryStore function.