### PR TITLE
In certain situations memory version of engine will throw an  DATA RACE error

### DIFF
--- a/engine/memory/engine.go
+++ b/engine/memory/engine.go
@@ -145,8 +145,8 @@ func (e *Engine) cleanupExpiredKeys() {
 }
 
 func (e *Engine) copyExpiredKeys() []string {
-	locksLock.RLock()
-	defer locksLock.RUnlock()
+    storeLock.RLock()
+	defer storeLock.RUnlock()
 	keys := make([]string, len(e.expire))
 	i := 0
 	for k := range e.expire {

--- a/engine/memory/engine.go
+++ b/engine/memory/engine.go
@@ -145,7 +145,7 @@ func (e *Engine) cleanupExpiredKeys() {
 }
 
 func (e *Engine) copyExpiredKeys() []string {
-    storeLock.RLock()
+	storeLock.RLock()
 	defer storeLock.RUnlock()
 	keys := make([]string, len(e.expire))
 	i := 0


### PR DESCRIPTION
Issue processExpiredKeys() needs to iterate through all the keys to check if any have expired.

The problem is the map is being updated while the map is being parsed.

Solution. 
Copy the map into a string array to avoid expiring already expired keys.
Add read locking to Exists and IsExpired.
Only call e.IsExpired if the key exists and their are no active locks for the key.

Testing.
Create a sample program that reads/writes to a memory cache.
Build the program using -race. 
Check for ```WARNING: DATA RACE``` errors.

