### PR TITLE
Adding locks to resolve potential race conditions in in-memory engine

### DIFF
--- a/engine/memory/engine.go
+++ b/engine/memory/engine.go
@@ -36,18 +36,21 @@ func NewMemoryStore(expirePoll time.Duration) *Engine {
 
 // Exists checks to see if a key exists in the store
 func (e *Engine) Exists(key string) bool {
+	storeLock.RLock()
+	defer storeLock.RUnlock()
+
 	_, ok := e.store[key]
 	return ok
 }
 
 // Get retrieves data from the store based on key, if it exists, else it returns an error
 func (e *Engine) Get(key string) (data []byte, err error) {
-	storeLock.RLock()
-	defer storeLock.RUnlock()
-
 	if !e.Exists(key) {
 		err = common.ErrNonExistentKey
 	}
+
+	storeLock.RLock()
+	defer storeLock.RUnlock()
 
 	data = e.store[key]
 
@@ -67,19 +70,29 @@ func (e *Engine) Put(key string, data []byte, expiry time.Time) error {
 
 // IsExpired checks to see if the key has expired
 func (e *Engine) IsExpired(key string) bool {
+	if !e.Exists(key) {
+		return true
+	}
+
+	storeLock.RLock()
+	defer storeLock.RUnlock()
+
 	if time.Now().After(e.expire[key]) {
 		go e.Expire(key)
 		return true
 	}
+
 	return false
 }
 
 // Expire marks the key as expired, and removes it from the storage engine
 func (e *Engine) Expire(key string) error {
-	_, ok := e.store[key]
-	if !ok {
+	if !e.Exists(key) {
 		return common.ErrNonExistentKey
 	}
+
+	storeLock.Lock()
+	defer storeLock.Unlock()
 
 	delete(e.store, key)
 	delete(e.expire, key)
@@ -114,13 +127,13 @@ func (e *Engine) Lock(key string) error {
 
 // Unlock removes the lock from a given key, if it doesn't exist it returns an error
 func (e *Engine) Unlock(key string) error {
+	locksLock.Lock()
+	defer locksLock.Unlock()
+
 	_, ok := e.locks[key]
 	if !ok {
 		return common.ErrNonExistentKey
 	}
-
-	locksLock.Lock()
-	defer locksLock.Unlock()
 
 	delete(e.locks, key)
 


### PR DESCRIPTION
On `master`, running `go test ./engine/memory -race` highlights some race conditions within the `memory` engine.

This PR resolves those race conditions, and also uses `Exists` where required to ensure locking is utilised.